### PR TITLE
Fix precision problem

### DIFF
--- a/src/core/lipp.h
+++ b/src/core/lipp.h
@@ -396,13 +396,13 @@ private:
             node = pending_two.top(); pending_two.pop();
         }
 
-        const double mid1_key = key1;
-        const double mid2_key = key2;
+        const long double mid1_key = key1;
+        const long double mid2_key = key2;
 
         const double mid1_target = node->num_items / 3;
         const double mid2_target = node->num_items * 2 / 3;
 
-        node->model.a = (mid1_target - mid2_target) / (mid1_key - mid2_key);
+        node->model.a = (mid2_target - mid1_target) / (mid2_key - mid1_key);
         node->model.b = mid1_target - node->model.a * mid1_key;
         RT_ASSERT(isfinite(node->model.a));
         RT_ASSERT(isfinite(node->model.b));
@@ -481,14 +481,16 @@ private:
                 RT_ASSERT(mid1_pos < mid2_pos);
                 RT_ASSERT(mid2_pos < size - 1);
 
-                const double mid1_key = (static_cast<double>(keys[mid1_pos]) + static_cast<double>(keys[mid1_pos + 1])) / 2;
-                const double mid2_key = (static_cast<double>(keys[mid2_pos]) + static_cast<double>(keys[mid2_pos + 1])) / 2;
+                const long double mid1_key =
+                        (static_cast<long double>(keys[mid1_pos]) + static_cast<long double>(keys[mid1_pos + 1])) / 2;
+                const long double mid2_key =
+                        (static_cast<long double>(keys[mid2_pos]) + static_cast<long double>(keys[mid2_pos + 1])) / 2;
 
                 node->num_items = size * static_cast<int>(BUILD_GAP_CNT + 1);
                 const double mid1_target = mid1_pos * static_cast<int>(BUILD_GAP_CNT + 1) + static_cast<int>(BUILD_GAP_CNT + 1) / 2;
                 const double mid2_target = mid2_pos * static_cast<int>(BUILD_GAP_CNT + 1) + static_cast<int>(BUILD_GAP_CNT + 1) / 2;
 
-                node->model.a = (mid1_target - mid2_target) / (mid1_key - mid2_key);
+                node->model.a = (mid2_target - mid1_target) / (mid2_key - mid1_key);
                 node->model.b = mid1_target - node->model.a * mid1_key;
                 RT_ASSERT(isfinite(node->model.a));
                 RT_ASSERT(isfinite(node->model.b));
@@ -593,7 +595,8 @@ private:
                     int i = 0;
                     int D = 1;
                     RT_ASSERT(D <= size-1-D);
-                    double Ut = double(keys[size-1-D] - keys[D]) / double(L - 2) + 1e-6;
+                    double Ut = (static_cast<long double>(keys[size - 1 - D]) - static_cast<long double>(keys[D])) /
+                                (static_cast<double>(L - 2)) + 1e-6;
                     while (i < size - 1 - D) {
                         while (i + D < size && keys[i + D] - keys[i] >= Ut) {
                             i ++;
@@ -604,13 +607,15 @@ private:
                         D = D + 1;
                         if (D * 3 > size) break;
                         RT_ASSERT(D <= size-1-D);
-                        Ut = double(keys[size-1-D] - keys[D]) / double(L - 2) + 1e-6;
+                        Ut = (static_cast<long double>(keys[size - 1 - D]) - static_cast<long double>(keys[D])) /
+                             (static_cast<double>(L - 2)) + 1e-6;
                     }
                     if (D * 3 <= size) {
                         stats.fmcd_success_times ++;
 
                         node->model.a = 1.0 / Ut;
-                        node->model.b = (L - node->model.a * (keys[size-1-D] + keys[D])) / 2;
+                        node->model.b = (L - node->model.a * (static_cast<long double>(keys[size - 1 - D]) +
+                                                              static_cast<long double>(keys[D]))) / 2;
                         RT_ASSERT(isfinite(node->model.a));
                         RT_ASSERT(isfinite(node->model.b));
                         node->num_items = L;
@@ -624,14 +629,16 @@ private:
                         RT_ASSERT(mid1_pos < mid2_pos);
                         RT_ASSERT(mid2_pos < size - 1);
 
-                        const double mid1_key = (static_cast<double>(keys[mid1_pos]) + static_cast<double>(keys[mid1_pos + 1])) / 2;
-                        const double mid2_key = (static_cast<double>(keys[mid2_pos]) + static_cast<double>(keys[mid2_pos + 1])) / 2;
+                        const long double mid1_key = (static_cast<long double>(keys[mid1_pos]) +
+                                                      static_cast<long double>(keys[mid1_pos + 1])) / 2;
+                        const long double mid2_key = (static_cast<long double>(keys[mid2_pos]) +
+                                                      static_cast<long double>(keys[mid2_pos + 1])) / 2;
 
                         node->num_items = size * static_cast<int>(BUILD_GAP_CNT + 1);
                         const double mid1_target = mid1_pos * static_cast<int>(BUILD_GAP_CNT + 1) + static_cast<int>(BUILD_GAP_CNT + 1) / 2;
                         const double mid2_target = mid2_pos * static_cast<int>(BUILD_GAP_CNT + 1) + static_cast<int>(BUILD_GAP_CNT + 1) / 2;
 
-                        node->model.a = (mid1_target - mid2_target) / (mid1_key - mid2_key);
+                        node->model.a = (mid2_target - mid1_target) / (mid2_key - mid1_key);
                         node->model.b = mid1_target - node->model.a * mid1_key;
                         RT_ASSERT(isfinite(node->model.a));
                         RT_ASSERT(isfinite(node->model.b));

--- a/src/core/lipp_base.h
+++ b/src/core/lipp_base.h
@@ -12,20 +12,20 @@ class LinearModel
 {
 public:
     double a = 0; // slope
-    double b = 0; // intercept
+    long double b = 0; // intercept
 
     LinearModel() = default;
-    LinearModel(double a, double b) : a(a), b(b) {}
+    LinearModel(double a, long double b) : a(a), b(b) {}
     explicit LinearModel(const LinearModel &other) : a(other.a), b(other.b) {}
 
     inline int predict(T key) const
     {
-        return std::floor(a * static_cast<double>(key) + b);
+        return std::floor(a * static_cast<long double>(key) + b);
     }
 
     inline double predict_double(T key) const
     {
-        return a * static_cast<double>(key) + b;
+        return a * static_cast<long double>(key) + b;
     }
 };
 


### PR DESCRIPTION
lipp would have a precision problem which will lead to segmentation fault or trigger the assertion. And the fix in develop branch will lead to the underlying key array being unsorted. 

One solution to this problem is using a higher precision type to replace double type(64 bit). Here I use long double type to convert the key which could avoid precision loss.